### PR TITLE
Compare to Vim’s built-in Python support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build
 Status](https://travis-ci.org/amoffat/snake.svg?branch=master)](https://travis-ci.org/amoffat/snake)
 
-Snake lets you use Python to its fullest extent to write vim plugins:
+Snake enhances [vim’s Python interface](http://vimdoc.sourceforge.net/htmldoc/if_pyth.html#Python) to make it *easy* to write vim plugins:
 
 ```python
 from snake import *
@@ -95,6 +95,8 @@ def uppercase_second_word():
 ```
 
 # How do I get it?
+
+(Your Vim version must include [`+python`](http://vimdoc.sourceforge.net/htmldoc/various.html#+python) to use Snake. You can check with `:version`.)
 
 ## Vundle
 


### PR DESCRIPTION
Made it clear that Snake doesn’t add the Python integration, but rather improves the integration so it is actually easy enough to write plugins with.

Mentioned the requirement for `+python` in “how do I get it” so people know the prerequisites for the software. This should help, for example, people running gvim on Windows, which does not include `+python`. I wrote the command `:version` instead of `:echo has('python')` to make the output easier to understand for those who don’t know that 0 and 1 are booleans in Vim.

Fixes https://github.com/amoffat/snake/issues/5