### PR TITLE
plugin_loader.py: insert into sys.meta_path, not overwrite

### DIFF
--- a/plugin/snake/plugin_loader.py
+++ b/plugin/snake/plugin_loader.py
@@ -165,7 +165,7 @@ Please install virtualenv and pip so that one can be created." % plugin_name)
 
 
 _snake_plugin_paths = [BUNDLE_DIR]
-sys.meta_path = [SnakePluginHook(_snake_plugin_paths)]
+sys.meta_path.insert(0, SnakePluginHook(_snake_plugin_paths))
 
 
 


### PR DESCRIPTION
We should not overwrite existing contents of `sys.meta_path`.

This causes strange subtle breakage with python 3.5 ([I patch snake to use python 3](https://github.com/intelfx/snake)):

```
$ LC_ALL=en_US.UTF-8 vim .vimrc
Error detected while processing /home/operator/.vim/bundle/snake/plugin/snake.vim:
line   10:
Traceback (most recent call last):
  File "<string>", line 8, in <module>
  File "/home/operator/.vim/bundle/snake/plugin/snake/__init__.py", line 664, in <module>
    from . import plugin_loader
  File "/home/operator/.vim/bundle/snake/plugin/snake/plugin_loader.py", line 200, in <module>
    import_source("vimrc", vimrc_path)
  File "/home/operator/.vim/bundle/snake/plugin/snake/plugin_loader.py", line 191, in import_source
    h = open(path, desc[1])
LookupError: unknown encoding: ascii
```