### PR TITLE
Reload snake post loading session.

### DIFF
--- a/plugin/snake.vim
+++ b/plugin/snake.vim
@@ -1,13 +1,22 @@
+let s:current_path=expand("<sfile>:p:h")
+function! LoadSnake()
 " contains custom vimscript stuff sourced by snake and the tests
-exec "source " . expand("<sfile>:p:h") . "/snake/prelude.vim"
+exec "source " . s:current_path . "/snake/prelude.vim"
 
 python << EOF
 import sys
 import vim
-sys.path.insert(0, vim.eval("expand('<sfile>:p:h')"))
+sys.path.insert(0, vim.eval('s:current_path'))
 
 if "snake" in sys.modules:
     snake = reload(snake)
 else:
     import snake
 EOF
+endfunction
+
+call LoadSnake()
+
+" Load snake once again so that it invalidates the function mappings
+" from the session file.
+autocmd SessionLoadPost * call LoadSnake()


### PR DESCRIPTION
* When a session is created using `:mksession`, the mappings to
  the python functions are saved based on the current session.
  The mappings should be reloaded when vim is opened again.
* The mappings are reloaded in the `SessionLoadPost` event.
* If there were no sessions, snake will be loaded only once.