### PR TITLE
Insert key map problems

### DIFF
--- a/plugin/snake/__init__.py
+++ b/plugin/snake/__init__.py
@@ -456,7 +456,10 @@ def key_map(key, maybe_fn=None, mode=NORMAL_MODE, recursive=False,
             fn = wrapped
 
         call = register_fn(fn)
-        command("%s <silent> %s :%s %s<CR>" % (map_command, key, PYTHON_CMD, call))
+        if mode == INSERT_MODE:
+            command("%s %s <C-\\><C-O>:%s %s<CR>" % (map_command, key, PYTHON_CMD, call))
+        else:
+            command("%s <silent> %s :%s %s<CR>" % (map_command, key, PYTHON_CMD, call))
 
     else:
         command("%s %s %s" % (map_command, key, maybe_fn))

--- a/tests.py
+++ b/tests.py
@@ -439,6 +439,17 @@ keys("Wviwa")
         self.assertEqual(output, "quick")
         self.assertEqual(changed, "The really fast brown fox jumps over the lazy dog")
 
+    def test_insert_key_map(self):
+        script = r"""
+@key_map("a", mode=INSERT_MODE)
+def change_words_and_move():
+    replace_word('Test')
+    keys('1w')
+
+keys("aaaa")
+"""
+        changed, output = run_vim(script, self.sample_text)
+        self.assertEqual(changed, "Test Test Test Test jumps over the lazy dog")
 
 
 class OptionsTests(VimTests):


### PR DESCRIPTION
This fixes an issue that I'm having defining key_maps for insertmode.

It also creates a test case for the problem.  Unfortunately, the test case fails for a different reason when run from the unittests.  (It seems that keys('aaaa') is only sending 'a' three times to vim instead of four times.  But I'm not sure of why.)  When I define the function in my .vimrc.py, the key_mapping seems to work just fine (Although, I don't have a call to keys() in my .vimrc.py)