### PR TITLE
Avoiding Setuptools is replacing distutils message.

### DIFF
--- a/plugin/snake/plugin_loader.py
+++ b/plugin/snake/plugin_loader.py
@@ -14,14 +14,14 @@ log = logging.getLogger("snake.plugins")
 # virtualenv may not exist, but we also may not need it if the user is just
 # running scripts that have no dependencies outside of the stdlib
 try:
-    import virtualenv
-except ImportError:
-    virtualenv = None
-
-try:
     import pip
 except ImportError:
     pip = None
+
+try:
+    import virtualenv
+except ImportError:
+    virtualenv = None
 
 # let's use our virtualenv_wrapper home if we have one, else default to
 # something sensible.  we'll use this to create our new virtualenvs for plugins


### PR DESCRIPTION
With these latest libraries, a warning message is shown at the start of vim.

```
UserWarning: Setuptools is replacing distutils.
  warnings.warn("Setuptools is replacing distutils.")
```

```
pip                               22.0.4
pipreqs                           0.4.10
pipx                              1.0.0
setuptools                        61.2.0
setuptools-rust                   0.11.5
setuptools-scm                    6.4.2
virtualenv                        20.14.0
```

Change the order of import libraries fixed this problem.